### PR TITLE
feat enable useFollowButton and useFollowingState to accept undefined properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereum-identity-kit",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Ethereum Identity Kit - Complete your dapp with the Ethereum identity stack.",
   "keywords": [
     "ethereum identity kit",

--- a/src/hooks/useFollowButton.ts
+++ b/src/hooks/useFollowButton.ts
@@ -107,8 +107,8 @@ export const useFollowButton = ({
   }, [followState, connectedAddress, pendingState])
 
   const handleAction = () => {
-    if (!connectedAddress) throw new Error('connectedAddress is required')
     if (!lookupAddress) throw new Error('lookupAddress is required')
+    if (!connectedAddress) return console.error('No connected address')
 
     setDisableHover(true)
 

--- a/src/hooks/useFollowButton.ts
+++ b/src/hooks/useFollowButton.ts
@@ -1,10 +1,10 @@
-import { Address } from 'viem'
 import { useMemo, useState } from 'react'
-import { useFollowingState } from './useFollowingState'
+import { Address } from 'viem'
 import { useTransactions } from '../context/transactionContext'
-import { getPendingTxListOps, extractAddressAndTag, formatListOpsTransaction } from '../utils/transactions'
-import { listOpAddListRecord, listOpAddTag, listOpRemoveListRecord, listOpRemoveTag } from '../utils/list-ops'
 import { FollowingState, InitialFollowingState } from '../types'
+import { listOpAddListRecord, listOpAddTag, listOpRemoveListRecord, listOpRemoveTag } from '../utils/list-ops'
+import { extractAddressAndTag, formatListOpsTransaction, getPendingTxListOps } from '../utils/transactions'
+import { useFollowingState } from './useFollowingState'
 
 export const useFollowButton = ({
   lookupAddress,
@@ -12,7 +12,7 @@ export const useFollowButton = ({
   selectedList,
   initialState,
 }: {
-  lookupAddress: Address
+  lookupAddress?: Address
   connectedAddress?: Address
   selectedList?: string
   initialState?: InitialFollowingState
@@ -43,7 +43,7 @@ export const useFollowButton = ({
     const allPendingListOps = getPendingTxListOps(pendingTxs)
     const filteredPendingListOps = allPendingListOps.filter((op) => {
       const { address } = extractAddressAndTag(op.data)
-      return address.toLowerCase() === lookupAddress.toLowerCase()
+      return address.toLowerCase() === lookupAddress?.toLowerCase()
     })
 
     return filteredPendingListOps
@@ -107,7 +107,8 @@ export const useFollowButton = ({
   }, [followState, connectedAddress, pendingState])
 
   const handleAction = () => {
-    if (!connectedAddress) return
+    if (!connectedAddress) throw new Error('connectedAddress is required')
+    if (!lookupAddress) throw new Error('lookupAddress is required')
 
     setDisableHover(true)
 

--- a/src/hooks/useFollowingState.ts
+++ b/src/hooks/useFollowingState.ts
@@ -1,15 +1,14 @@
 import { useQuery } from '@tanstack/react-query'
 import { useEffect, useMemo, useState } from 'react'
-import { isAddress } from 'viem'
 import { useTransactions } from '../context'
+import { fetchFollowState } from '../utils/api/fetch-follow-state'
 import { Address } from '../types/address'
 import { FollowState, InitialFollowingState } from '../types/followState'
 import { ProfileListType } from '../types/profile'
-import { fetchFollowState } from '../utils/api/fetch-follow-state'
 
 interface UseFollowingStateProps {
   lookupAddressOrName?: Address | string
-  connectedAddress?: Address | string
+  connectedAddress?: Address
   list?: ProfileListType
   initialState?: InitialFollowingState
 }
@@ -33,9 +32,6 @@ export const useFollowingState = ({
     queryKey: ['followingState', lookupAddressOrName, connectedAddress, list, fetchFresh, initialState],
     queryFn: async () => {
       if (!lookupAddressOrName) throw new Error('lookupAddressOrName is required')
-      if (!connectedAddress) throw new Error('connectedAddress is required')
-      if (!isAddress(connectedAddress)) throw new Error('connectedAddress must be a valid address')
-      if (!isAddress(lookupAddressOrName)) throw new Error('lookupAddressOrName must be a valid address')
 
       if (initialState && !fetchFresh)
         return {


### PR DESCRIPTION
While implementing the `useFollowButton` hook, I noticed a few small improvements that could enhance the developer experience. 

Currently, only `connectedAddress` is allowed to be undefined but not `targetAddress`. This PR enables both useFollowButton and useFollowingState to gracefully handle undefined properties for both parameters, making it more robust during component initialization and state updates.