### PR TITLE
Handle broken profile row headers

### DIFF
--- a/src/components/molecules/profile-list-row/ProfileListRow.tsx
+++ b/src/components/molecules/profile-list-row/ProfileListRow.tsx
@@ -58,7 +58,7 @@ const ProfileListRow: React.FC<ProfileListRowProps> = ({
 
   React.useEffect(() => {
     setHeaderImageError(false)
-  }, [headerImage, account?.ens?.name])
+  }, [headerImage, account?.ens?.name, showHeaderImage])
 
   return (
     <ProfileRowWrapper profile={profile} connectedAddress={connectedAddress} selectedList={selectedList} showFollowsYouBadges={showFollowsYouBadges} showTooltip={showProfileTooltip}>

--- a/src/components/molecules/profile-list-row/ProfileListRow.tsx
+++ b/src/components/molecules/profile-list-row/ProfileListRow.tsx
@@ -51,14 +51,26 @@ const ProfileListRow: React.FC<ProfileListRowProps> = ({
     queryFn: async () => (profile.ens ? profile : await fetchProfileAccount(profile.address)),
   })
 
+  const [headerImageError, setHeaderImageError] = React.useState(false)
   const headerImage = account?.ens?.header || account?.ens?.records?.header
-  const headerImageSrc = validateEnsHeader(headerImage, account?.ens?.name)
+  const headerImageSrc = headerImageError ? undefined : validateEnsHeader(headerImage, account?.ens?.name)
+  const hasHeaderImage = showHeaderImage && !!headerImageSrc
+
+  React.useEffect(() => {
+    setHeaderImageError(false)
+  }, [headerImage, account?.ens?.name])
 
   return (
     <ProfileRowWrapper profile={profile} connectedAddress={connectedAddress} selectedList={selectedList} showFollowsYouBadges={showFollowsYouBadges} showTooltip={showProfileTooltip}>
-      <div className={clsx('profile-list-row', showHeaderImage && 'has-header-image')} style={{ height: rowHeight }}>
-        {showHeaderImage && headerImageSrc && (
-          <img src={headerImageSrc} alt="" className="profile-list-row-header-image" style={{ height: rowHeight }} />
+      <div className={clsx('profile-list-row', hasHeaderImage && 'has-header-image')} style={{ height: rowHeight }}>
+        {hasHeaderImage && (
+          <img
+            src={headerImageSrc}
+            alt=""
+            className="profile-list-row-header-image"
+            style={{ height: rowHeight }}
+            onError={() => setHeaderImageError(true)}
+          />
         )}
         <div className="profile-list-row-details">
           {isAccountLoading ? (


### PR DESCRIPTION
Fix profile list rows so failed ENS header images are removed instead of leaving header-image styling active. The row now tracks image load errors, only applies has-header-image when a usable header source exists, and resets that error state when the header URL or ENS name changes. Validated with npm run typecheck and npm run lint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved header image handling in profile list rows to avoid showing broken images and to retry loading when the profile or ENS header changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->